### PR TITLE
align bcfsplitter with inputfilehandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
 /test/dx_run.log
+dx_run.log
 /test/test_data/test_input.sites.unfiltered.txt
 /test/test_data/reference.fasta
 /test/test_data/reference.fasta.fai
+uv.lock
+bcfsplitter
+bcfsplitter.egg-info
+.idea
+test/__pycache__
+test/reference.fasta
+test/reference.fasta.fai
+test/test_input1*
+test/test_input2*

--- a/Readme.md
+++ b/Readme.md
@@ -41,38 +41,6 @@ dx describe file-1234567890ABCDEFGHIJKLMN
 
 **Note:** This README pertains to data included as part of the DNANexus project "MRC - Variant Filtering" (project-G2XK5zjJXk83yZ598Z7BpGPk)
 
-### Changelog
-
-* v2.0.2
-  * Have aligned the script in keeping with the latest InputFileHandler class from general_utilities. All functionality remains the same, apart from that the input files should now have two columns: vcf and vcf_index:
-  
-  | vcf             | vcf_idx         |
-  |-----------------|-----------------|
-  | file-abcde12345 | file-abcde12345 |
-  | file-abcde12345 | file-abcde12345 |
-
-
-* v2.0.1
-  * Fixed a bug where skipped sites were duplicated if processing multiple VCFs in one job.
-
-* v2.0.0
-  * Added support for WGS data. This comes with several changes under-the-hood to support issues with the larger WGS data. These changes will not effect processing of WES data, but please see below for specific changes:
-    * Modified standard number of CPUs per-vcf to 8. We have done extensive testing to ensure that the process is $O(n^2)$ in terms of CPU usage – e.g., 2 CPUs = 60m / VCF, 4 CPUs = 30m / VCF
-    * Fixed an issue with sites with large number of alternate alleles.
-      * Issue can lead to excessive memory requirements when processing some VCFs.
-      * We have added a method to filter sites with excessive alternate alleles, which can be triggered using the `alt_allele_threshold` parameter.
-      * This parameter is set to 99999 by default, so will not affect WES processing
-      * We recommend a setting of 15 when analysing WGS data
-      * All sites that are filtered will be reported in the `skipped_sites.{output_name}.tsv`
-  * Several quality-of-life changes to the codebase to improve readability and maintainability
-  * Implemented newer version of `general_utilities`
-  * Added docstrings to all functions
-  * Implemented tests – please see `Readme.developer.md` for more information.
-  * Fixed a bug where star alleles could result in an unexpected number of variants in a split bcf file
-
-* v1.0.0
-  * Initial numbered release, see git logs for previous changes.
-
 ### Background
 
 UKBiobank provides individual .vcf.gz files. This is the same number as for the 200k release despite the sample size 

--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,15 @@ dx describe file-1234567890ABCDEFGHIJKLMN
 
 ### Changelog
 
+* v2.0.2
+  * Have aligned the script in keeping with the latest InputFileHandler class from general_utilities. All functionality remains the same, apart from that the input files should now have two columns: vcf and vcf_index:
+  
+  | vcf             | vcf_idx         |
+  |-----------------|-----------------|
+  | file-abcde12345 | file-abcde12345 |
+  | file-abcde12345 | file-abcde12345 |
+
+
 * v2.0.1
   * Fixed a bug where skipped sites were duplicated if processing multiple VCFs in one job.
 

--- a/bcfsplitter/bcfsplitter.py
+++ b/bcfsplitter/bcfsplitter.py
@@ -426,7 +426,7 @@ def main(input_vcfs: dict, chunk_size: int, alt_allele_threshold: int, output_na
 
     # And launch individual jobs
     n_vcfs = 0
-    with Path(input_vcfs).open('r') as input_vcf_reader:
+    with input_vcfs.open('r') as input_vcf_reader:
         # read in each line of the input file
         for line in input_vcf_reader:
             # Skip the header line if it doesn't start with 'file-' (e.g. the header should be 'vcf / vcf_idx'

--- a/bcfsplitter/bcfsplitter.py
+++ b/bcfsplitter/bcfsplitter.py
@@ -34,8 +34,8 @@ def ingest_human_reference(human_reference: dict, human_reference_index: dict, c
         CMD_EXEC from this module.
     """
 
-    reference = InputFileHandler(str(human_reference)).get_file_handle()
-    InputFileHandler(str(human_reference_index)).get_file_handle()
+    reference = InputFileHandler(human_reference).get_file_handle()
+    InputFileHandler(human_reference_index).get_file_handle()
 
     # if the file is not unzipped, unzip it
     if reference.suffix == '.gz':
@@ -415,7 +415,7 @@ def main(input_vcfs: dict, chunk_size: int, alt_allele_threshold: int, output_na
     # dxpy.download_dxfile(input_vcfs.get_id(), 'vcf_list.txt')  # Actually download the file
 
     # download the file
-    input_vcfs = InputFileHandler(str(input_vcfs)).get_file_handle()
+    input_vcfs = InputFileHandler(input_vcfs).get_file_handle()
 
     reference = ingest_human_reference(human_reference, human_reference_index)
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -117,16 +117,22 @@
     "assetDepends": [],
     "execDepends": [
       {
+        "name": "uv",
+        "package_manager": "pip"
+      },
+      {
         "name": "general_utilities",
         "package_manager": "git",
-        "url":  "https://github.com/mrcepid-rap/general_utilities.git",
-        "tag": "v1.5.1",
-        "build_commands": "pip3 install ."
+        "url": "https://github.com/mrcepid-rap/general_utilities.git",
+        "tag": "main",
+        "build_commands": "uv pip install --system ."
       }
     ]
   },
   "access": {
-    "network": ["*"],
+    "network": [
+      "*"
+    ],
     "allProjects": "VIEW"
   },
   "regionalOptions": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "BCFSplitter",
   "summary": "Normalises and splits a VCF into smaller BCFs",
   "dxapi": "1.0.0",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "inputSpec": [
     {
       "name": "input_vcfs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,22 @@
-[tool.poetry]
+[project]
 name = "bcfsplitter"
 version = "2.0.0"
 description = ""
-authors = ["Eugene Gardner <eugene.gardner@mrc-epid.cam.ac.uk>"]
+authors = [
+    { name = "Eugene Gardner", email = "eugene.gardner@mrc-epid.cam.ac.uk" },
+    { name = "Alish Palmos", email = "alish.palmos@insmed.com" }
+]
 readme = "README.md"
+requires-python = ">=3.8,<3.9"
 
-[tool.poetry.dependencies]
-python = "~3.8"
-dxpy = "0.346.0"
-pytest = "^7.4.0"
-pysam = "^0.22.1"
-general-utilities = {git = "https://github.com/mrcepid-rap/general_utilities.git", rev = "v1.5.1"}
+dependencies = [
+    "dxpy==0.346.0",
+    "pytest>=7.4.0,<8.0.0",
+    "pysam>=0.22.1,<0.23.0",
+    "general-utilities @ git+https://github.com/mrcepid-rap/general_utilities.git@feature/implement-a-fileparsing-class"
+]
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bcfsplitter"
-version = "2.0.0"
+version = "2.0.2"
 description = ""
 authors = [
     { name = "Eugene Gardner", email = "eugene.gardner@mrc-epid.cam.ac.uk" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "dxpy==0.346.0",
     "pytest>=7.4.0,<8.0.0",
     "pysam>=0.22.1,<0.23.0",
-    "general-utilities @ git+https://github.com/mrcepid-rap/general_utilities.git@feature/implement-a-fileparsing-class"
+    "general-utilities @ git+https://github.com/mrcepid-rap/general_utilities.git@main"
 ]
 
 [build-system]

--- a/test/bcfsplitter_test.py
+++ b/test/bcfsplitter_test.py
@@ -12,11 +12,13 @@ from typing import Optional, List, Tuple
 from pysam import VariantFile
 
 from general_utilities.association_resources import replace_multi_suffix
-from general_utilities.job_management.command_executor import DockerMount, CommandExecutor
+from general_utilities.job_management.command_executor import DockerMount, CommandExecutor, \
+    build_default_command_executor
 from bcfsplitter.bcfsplitter import generate_site_tsv, count_variant_list_and_filter, normalise_and_left_correct, \
     split_sites, split_bcfs, write_information_files, ingest_human_reference, download_vcf
 
 test_data_dir = Path(__file__).parent / 'test_data'
+CMD_EXEC = build_default_command_executor()
 
 EXPECTED_VCF_VALUES = [{'final': 845, 'missing': 6, 'original': 835,
                         'vcf': test_data_dir / 'test_input1.vcf.gz',
@@ -110,17 +112,17 @@ def test_ingest_human_reference(tmp_data_dir, reference, reference_index):
          test_data_dir / 'test_input2.vcf.gz.tbi')
     ]
 )
-def test_download_vcf(tmp_data_dir, input_vcf, input_index):
+def test_download_vcf(tmp_data_dir, input_vcf, cmd_exec: CommandExecutor = CMD_EXEC):
     """Test the download of a VCF file.
 
     :param input_vcf: The name of the VCF file to be downloaded.
+    :param cmd_exec: A CommandExecutor object to run commands on the docker container.
     """
 
     # Convert to Path objects relative to tmp_data_dir
     input_vcf = tmp_data_dir / input_vcf
-    input_index = tmp_data_dir / input_index
 
-    vcfpath, vcf_zie = download_vcf(input_vcf, input_index)
+    vcfpath, vcf_zie = download_vcf(input_vcf, cmd_exec)
 
     assert vcfpath.exists()
     assert vcf_zie == input_vcf.stat().st_size


### PR DESCRIPTION
Make bcfsplitter work with the new InputFileHandler class from general_utilities - removes the dependency on DNA Nexus